### PR TITLE
update buf.lock for googleapis change

### DIFF
--- a/src/test/resources/testData/completion/external/buf.lock
+++ b/src/test/resources/testData/completion/external/buf.lock
@@ -4,7 +4,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    branch: main
-    commit: 84c3cad756d2435982d9e3b72680fa96
-    digest: b1-GVZocI28gwtZCKNAO4Jd83jaE_XMjcAuEBtjnWvybO0=
-    create_time: 2021-08-17T15:06:58.03881Z
+    commit: d1263fe26f8e430a967dc22a4d0cad18

--- a/src/test/resources/testData/resolve/external/buf.lock
+++ b/src/test/resources/testData/resolve/external/buf.lock
@@ -4,7 +4,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    branch: main
-    commit: 84c3cad756d2435982d9e3b72680fa96
-    digest: b1-GVZocI28gwtZCKNAO4Jd83jaE_XMjcAuEBtjnWvybO0=
-    create_time: 2021-08-17T15:06:58.03881Z
+    commit: d1263fe26f8e430a967dc22a4d0cad18


### PR DESCRIPTION
Fix the tests in intellij-buf to bump to the latest googleapis/googleapis dependency (the pinned version no longer exists after refactoring this module in the BSR).