### PR TITLE
Improve error handling of v2 cache folder

### DIFF
--- a/src/main/kotlin/build/buf/intellij/resolve/BufCacheLibrary.kt
+++ b/src/main/kotlin/build/buf/intellij/resolve/BufCacheLibrary.kt
@@ -41,10 +41,6 @@ class BufCacheLibrary(private val name: String, private val cacheDir: String) : 
     override fun hashCode(): Int = Objects.hash(name, cacheDir)
 
     override fun getSourceRoots(): Collection<VirtualFile> {
-        val root = VirtualFileManager.getInstance().findFileByNioPath(Path.of(cacheDir))
-        if (root == null || !root.isValid) {
-            return emptyList()
-        }
-        return root.children.toList()
+        return listOfNotNull(VirtualFileManager.getInstance().findFileByNioPath(Path.of(cacheDir)))
     }
 }

--- a/src/main/kotlin/build/buf/intellij/resolve/BufRootsProvider.kt
+++ b/src/main/kotlin/build/buf/intellij/resolve/BufRootsProvider.kt
@@ -22,6 +22,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.AdditionalLibraryRootsProvider
 import com.intellij.openapi.roots.SyntheticLibrary
+import com.intellij.openapi.util.SystemInfoRt
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.SystemProperties
@@ -41,6 +42,12 @@ class BufRootsProvider : AdditionalLibraryRootsProvider() {
             if (bufCacheDir != null) {
                 return Path.of(bufCacheDir)
             }
+            if (SystemInfoRt.isWindows) {
+                val localAppData = env["LOCALAPPDATA"]
+                if (localAppData != null) {
+                    return Path.of(localAppData, "buf")
+                }
+            }
             val xdgCacheHome = env["XDG_CACHE_HOME"]
             if (xdgCacheHome != null) {
                 return Path.of(xdgCacheHome, "buf")
@@ -49,7 +56,6 @@ class BufRootsProvider : AdditionalLibraryRootsProvider() {
             if (home != null) {
                 return Path.of(home, ".cache", "buf")
             }
-            // TODO: LOCALAPPDATA on Windows
             return Path.of(SystemProperties.getUserHome(), ".cache", "buf")
         }
 


### PR DESCRIPTION
Use a temporary directory to avoid issues with race conditions, perform an atomic move when successful, add error handling and logging, and ensure proper cleanup on error.