### PR TITLE
Fix intellij-buf build w/ new buf versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(11))
-        vendor.set(JvmVendorSpec.AZUL)
     }
 }
 
@@ -81,7 +80,7 @@ tasks {
     register<Exec>("licenseHeaderInstall") {
         description = "Installs the bufbuild/buf license-header CLI to build/gobin."
         environment("GOBIN", file("build/gobin").canonicalPath)
-        commandLine("go", "install", "github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@latest")
+        commandLine("go", "install", "github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v${libs.versions.buf.get()}")
     }
 
     register<Exec>("licenseHeader") {
@@ -95,6 +94,8 @@ tasks {
             properties("buf.license.header.holder").get(),
             "--year-range",
             properties("buf.license.header.range").get(),
+            "--ignore",
+            "/cachev",
         )
     }
 

--- a/build_versions.py
+++ b/build_versions.py
@@ -1,3 +1,17 @@
+# Copyright 2022-2023 Buf Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #!/usr/bin/env python3
 
 import argparse

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 annotations = "24.0.1"
-buf = "1.19.0"
+buf = "1.22.0"
 junit = "5.9.3"
 
 # plugins


### PR DESCRIPTION
Instead of installing the latest license-header binary, we should pin it to the same version as the version of Buf we're using. Upgrade buf to the latest v1.22.0 release, and relax the restriction in the build that we need an Azul toolchain - any Java 11 toolchain should work until we upgrade to Java 17.