### PR TITLE
Add displayName attribute to fix error

### DIFF
--- a/gradle/test-intellij.versions.toml
+++ b/gradle/test-intellij.versions.toml
@@ -1,2 +1,2 @@
 [versions]
-versionList = "IIC-231.9011.34,IIC-213.7172.25"
+versionList = "IIC-232.8660.185,IIC-213.7172.25"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,7 +13,6 @@
         <fileBasedIndex implementation="build.buf.intellij.index.BufModuleIndex"/>
         <additionalLibraryRootsProvider implementation="build.buf.intellij.resolve.BufRootsProvider"/>
 
-
         <highlightingPassFactory implementation="build.buf.intellij.annotator.BufAnalyzePassFactoryRegistrar"/>
         <statusBarWidgetFactory id="bufLintWidget"
                                 implementation="build.buf.intellij.status.BufCLIWidgetFactory"
@@ -21,18 +20,17 @@
 
         <formattingService implementation="build.buf.intellij.formatter.BufFormatterService"/>
 
-
         <projectService serviceInterface="build.buf.intellij.settings.BufProjectSettingsService"
                         serviceImplementation="build.buf.intellij.settings.impl.BufProjectSettingsServiceImpl"/>
         <projectConfigurable instance="build.buf.intellij.configurable.BufConfigurable"
                              groupId="tools"
-                             id="tools.buf"/>
+                             id="tools.buf"
+                             displayName="Buf"/>
 
         <localInspection language="protobuf" shortName="BufCLINotInstalled" bundle="messages.BufBundle"
                          key="buf.inspection.cli.not.installed"
                          groupKey="buf.inspections.group.name" enabledByDefault="true"
                          implementationClass="build.buf.intellij.inspections.BufNotInstalledInspection"/>
-
 
         <globalInspection language="protobuf" groupBundle="messages.BufBundle" groupKey="buf.inspections.group.name"
                           shortName="BufAnalyze" displayName="Buf Analyze"


### PR DESCRIPTION
Update the plugin to add a displayName attribute to fix an error seen in IntelliJ 2023.2 with the latest plugin. Update build verification to run against the latest IntelliJ.

Fixes #128.