### PR TITLE
Update plugin to require 2022.3 or later

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,12 +48,12 @@ jobs:
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1.1.0
 
-      # Setup Java 11 environment for the next steps
+      # Setup Java 17 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: gradle
 
       # Setup Go (including module cache) for license-header

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -12,8 +12,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      # Setup Java environment for the next steps
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 17
       # Run Qodana inspections
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2023.2.1
+        with:
+          cache-default-branch-only: true
         # Qodana currently failing - perhaps resolved in a follow up
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,12 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      # Setup Java 11 environment for the next steps
+      # Setup Java 17 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: gradle
 
       # Set environment variables

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v3
 
-      # Setup Java 11 environment for the next steps
+      # Setup Java 17 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: gradle
 
       # Run IDEA prepared for UI testing

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,13 +33,13 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 
 // Set the JVM language level used to build the project. Use Java 11 for 2020.3+, and Java 17 for 2022.2+.
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(17)
 }
 
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@
 pluginGroup=intellij
 pluginName=intellij-buf
 # SemVer format -> https://semver.org
-pluginVersion=0.1.6
+pluginVersion=0.2.0
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=213
+pluginSinceBuild=223
 pluginUntilBuild=999.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IU
-platformVersion=2021.3.2
+platformVersion=2022.3.3
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=idea.plugin.protoeditor, org.jetbrains.plugins.yaml

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ platformVersion=2022.3.3
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=idea.plugin.protoeditor, org.jetbrains.plugins.yaml
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion=8.1.1
+gradleVersion=8.2.1
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 annotations = "24.0.1"
-buf = "1.22.0"
+buf = "1.26.1"
 junit = "5.10.0"
 
 # plugins

--- a/gradle/test-intellij.versions.toml
+++ b/gradle/test-intellij.versions.toml
@@ -1,2 +1,2 @@
 [versions]
-versionList = "IIC-232.8660.185,IIC-213.7172.25"
+versionList = "IIC-232.8660.185,IIC-223.8836.41"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/qodana.yml
+++ b/qodana.yml
@@ -2,6 +2,8 @@
 # https://www.jetbrains.com/help/qodana/qodana-yaml.html
 
 version: 1.0
+linter: jetbrains/qodana-jvm-community:latest
+projectJDK: 17
 profile:
   name: qodana.recommended
 exclude:

--- a/src/main/kotlin/build/buf/intellij/BufPluginService.kt
+++ b/src/main/kotlin/build/buf/intellij/BufPluginService.kt
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package build.buf.intellij.annotator
+package build.buf.intellij
 
-import com.intellij.codeHighlighting.TextEditorHighlightingPassFactoryRegistrar
-import com.intellij.codeHighlighting.TextEditorHighlightingPassRegistrar
-import com.intellij.openapi.project.Project
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
 
-class BufAnalyzePassFactoryRegistrar : TextEditorHighlightingPassFactoryRegistrar {
-    override fun registerHighlightingPassFactory(registrar: TextEditorHighlightingPassRegistrar, project: Project) {
-        BufAnalyzePassFactory(registrar)
-    }
+/**
+ * Application level service used as disposable.
+ * [Reference](https://plugins.jetbrains.com/docs/intellij/disposers.html?from=IncorrectParentDisposable#choosing-a-disposable-parent)
+ */
+@Service(Service.Level.APP)
+class BufPluginService : Disposable {
+    override fun dispose() {}
 }

--- a/src/main/kotlin/build/buf/intellij/inspections/BufAnalyzeInspection.kt
+++ b/src/main/kotlin/build/buf/intellij/inspections/BufAnalyzeInspection.kt
@@ -15,6 +15,7 @@
 package build.buf.intellij.inspections
 
 import build.buf.intellij.BufBundle
+import build.buf.intellij.BufPluginService
 import build.buf.intellij.annotator.BufAnalyzeResult
 import build.buf.intellij.annotator.BufAnalyzeUtils
 import build.buf.intellij.annotator.createAnnotationsForFile
@@ -24,6 +25,7 @@ import com.intellij.codeInspection.*
 import com.intellij.lang.annotation.AnnotationSession
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.components.service
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.util.Disposer
 import com.intellij.protobuf.lang.psi.PbFile
@@ -33,6 +35,8 @@ class BufAnalyzeInspection : GlobalSimpleInspectionTool() {
     companion object {
         private const val SHORT_NAME = "BufAnalyze"
     }
+
+    private val appService = service<BufPluginService>()
 
     override fun getShortName(): String = SHORT_NAME
 
@@ -50,7 +54,7 @@ class BufAnalyzeInspection : GlobalSimpleInspectionTool() {
         if (file !is PbFile) return
         val project = manager.project
         val disposable = project.messageBus.createDisposableOnAnyPsiChange()
-            .also { Disposer.register(project, it) }
+            .also { Disposer.register(appService, it) }
 
         val contentRootForFile = ProjectFileIndex.getInstance(project)
             .getContentRootForFile(file.virtualFile) ?: return


### PR DESCRIPTION
Update the baseline for the plugin to 2022.3 or later versions. This will allow us to migrate to newer APIs and start compiling on Java 17 (instead of 11).