### PR TITLE
Set outputs for buf CLI / license-header

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,10 @@ plugins {
 group = properties("pluginGroup").get()
 version = properties("pluginVersion").get()
 
+val bufCLIFile = project.layout.buildDirectory.file("gobin/buf").get().asFile
+val bufLicenseHeaderCLIFile = project.layout.buildDirectory.file("gobin/license-header").get().asFile
+val bufLicenseHeaderCLIPath: String = bufLicenseHeaderCLIFile.absolutePath
+
 // Configure project's dependencies
 repositories {
     mavenCentral()
@@ -76,7 +80,8 @@ koverReport {
 tasks {
     register<Exec>("licenseHeaderInstall") {
         description = "Installs the bufbuild/buf license-header CLI to build/gobin."
-        environment("GOBIN", file("build/gobin").canonicalPath)
+        environment("GOBIN", bufLicenseHeaderCLIFile.parentFile.absolutePath)
+        outputs.file(bufLicenseHeaderCLIFile)
         commandLine("go", "install", "github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v${libs.versions.buf.get()}")
     }
 
@@ -84,7 +89,7 @@ tasks {
         description = "Runs the license-header CLI to add/update license information to source code."
         dependsOn("licenseHeaderInstall")
         commandLine(
-            file("build/gobin/license-header").canonicalPath,
+            bufLicenseHeaderCLIPath,
             "--license-type",
             properties("buf.license.header.type").get(),
             "--copyright-holder",
@@ -100,7 +105,7 @@ tasks {
         description = "Verifies that all source code has appropriate license headers."
         dependsOn("licenseHeaderInstall")
         commandLine(
-            file("build/gobin/license-header").canonicalPath,
+            bufLicenseHeaderCLIPath,
             "--license-type",
             properties("buf.license.header.type").get(),
             "--copyright-holder",
@@ -116,7 +121,8 @@ tasks {
 
     register<Exec>("bufInstall") {
         description = "Installs the bufbuild/buf CLI to build/gobin."
-        environment("GOBIN", file("build/gobin").canonicalPath)
+        environment("GOBIN", bufCLIFile.parentFile.absolutePath)
+        outputs.file(bufCLIFile)
         commandLine("go", "install", "github.com/bufbuild/buf/cmd/buf@v${libs.versions.buf.get()}")
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,7 +127,7 @@ tasks {
     }
 
     check {
-        dependsOn("licenseHeaderVerify", "bufInstall")
+        dependsOn("licenseHeaderVerify")
     }
 
     test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,8 +131,10 @@ tasks {
     }
 
     test {
+        dependsOn("bufInstall")
         environment("BUF_CACHE_DIR", File(project.projectDir.path + "/src/test/resources/testData/cachev1").absolutePath)
         systemProperty("NO_FS_ROOTS_ACCESS_CHECK", "true") // weird issue on linux
+        systemProperty("BUF_CLI", bufCLIFile.absolutePath)
         useJUnitPlatform()
     }
 

--- a/src/test/kotlin/build/buf/intellij/base/BufTestBase.kt
+++ b/src/test/kotlin/build/buf/intellij/base/BufTestBase.kt
@@ -28,7 +28,14 @@ abstract class BufTestBase : CodeInsightFixtureTestCase<ModuleFixtureBuilder<*>>
 
     override fun setUp() {
         super.setUp()
-        val cliPath = "build/gobin/buf"
+        val cliPath = System.getProperty("BUF_CLI", "build/gobin/buf")
+        val cliFile = File(cliPath)
+        if (!cliFile.isFile) {
+            throw IllegalStateException("invalid buf CLI: ${cliFile.absolutePath}")
+        }
+        if (!cliFile.canExecute()) {
+            throw IllegalStateException("unable to execute buf CLI: ${cliFile.absolutePath}")
+        }
         if (project.bufSettings.state.bufCLIPath != cliPath) {
             project.bufSettings.state = project.bufSettings.state.copy(
                 bufCLIPath = cliPath


### PR DESCRIPTION
Update the tasks to install the Buf CLI and license-header CLI to add outputs to correctly inform the build of what is created.