### PR TITLE
Preserve newlines with buf format

### DIFF
--- a/src/main/kotlin/build/buf/intellij/annotator/BufAnalyzeUtils.kt
+++ b/src/main/kotlin/build/buf/intellij/annotator/BufAnalyzeUtils.kt
@@ -189,7 +189,8 @@ object BufAnalyzeUtils {
         project: Project,
         owner: Disposable,
         workingDirectory: Path,
-        arguments: List<String>
+        arguments: List<String>,
+        preserveNewlines: Boolean = false,
     ): Iterable<String> = withContext(Dispatchers.IO) {
         val bufExecutable = BufCLIUtils.getConfiguredBufExecutable(project) ?: return@withContext emptyList()
         val cmd = AtomicReference<String>()
@@ -205,7 +206,7 @@ object BufAnalyzeUtils {
             override fun onTextAvailable(event: ProcessEvent, outputType: com.intellij.openapi.util.Key<*>) {
                 when (outputType) {
                     ProcessOutputType.SYSTEM -> cmd.set(event.text.trimEnd())
-                    ProcessOutputType.STDOUT -> stdout.add(event.text.trimEnd())
+                    ProcessOutputType.STDOUT -> stdout.add(if (preserveNewlines) event.text else event.text.trimEnd())
                 }
             }
 

--- a/src/main/kotlin/build/buf/intellij/formatter/BufFormatterService.kt
+++ b/src/main/kotlin/build/buf/intellij/formatter/BufFormatterService.kt
@@ -54,7 +54,8 @@ class BufFormatterService : AsyncDocumentFormattingService() {
                         project,
                         disposable,
                         contentRootForFile.toNioPath(),
-                        listOf("format", relativePath)
+                        listOf("format", relativePath),
+                        preserveNewlines = true,
                     )
                 }
                 if (output.firstOrNull()?.startsWith("unknown command") == true) {
@@ -63,7 +64,7 @@ class BufFormatterService : AsyncDocumentFormattingService() {
                         BufBundle.message("formatter.cli.version.not.supported")
                     )
                 } else {
-                    request.onTextReady(output.joinToString(separator = "\n"))
+                    request.onTextReady(output.joinToString(separator = ""))
                 }
             }
 

--- a/src/test/kotlin/build/buf/intellij/formatter/BufFormatterTest.kt
+++ b/src/test/kotlin/build/buf/intellij/formatter/BufFormatterTest.kt
@@ -18,6 +18,7 @@ import build.buf.intellij.base.BufTestBase
 import com.intellij.codeInsight.actions.ReformatCodeProcessor
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.psi.codeStyle.CodeStyleManager
+import com.intellij.util.io.readText
 
 class BufFormatterTest : BufTestBase() {
     fun testFormatting() {
@@ -54,8 +55,19 @@ class BufFormatterTest : BufTestBase() {
               string user_id = 1;
               // The user's email.
               string email = 2;
-            }
-        """.trimIndent()
+            }""".trimIndent() + "\n"
         )
+    }
+
+    fun testLargeFile() {
+        val file = myFixture.configureByText(
+            "largeprotofile.proto",
+            findTestDataFolder().resolve("formatter/largeprotofile-before.proto").readText(),
+        )
+        WriteCommandAction.runWriteCommandAction(project, ReformatCodeProcessor.getCommandName(), null, {
+            CodeStyleManager.getInstance(project).reformat(file)
+        })
+        val expected = findTestDataFolder().resolve("formatter/largeprotofile-after.proto").readText()
+        myFixture.checkResult(expected)
     }
 }

--- a/src/test/resources/testData/formatter/largeprotofile-after.proto
+++ b/src/test/resources/testData/formatter/largeprotofile-after.proto
@@ -1,0 +1,616 @@
+// Copyright 2022-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+message Test1 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test2 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test3 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test4 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test5 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test6 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test7 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test8 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test9 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test10 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test11 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test12 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test13 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test14 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test15 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test16 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test17 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test18 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test19 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test20 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test21 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test22 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test23 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test24 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test25 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test26 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test27 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test28 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test29 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test30 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test31 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test32 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test33 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test34 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test35 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test36 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test37 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test38 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test39 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test40 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test41 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test42 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test43 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test44 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test45 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test46 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test47 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test48 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test49 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test50 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test51 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test52 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test53 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test54 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test55 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test56 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test57 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test58 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test59 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test60 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test61 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test62 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test63 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test64 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test65 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test66 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test67 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test68 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test69 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test70 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test71 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test72 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test73 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test74 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test75 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test76 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test77 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test78 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test79 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test80 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test81 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test82 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test83 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test84 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test85 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test86 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test87 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test88 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test89 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test90 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test91 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test92 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test93 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test94 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test95 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test96 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test97 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test98 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test99 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}
+message Test100 {
+  string s = 1;
+  int64 i64 = 2;
+  bytes b = 3;
+  repeated string rs = 4;
+}

--- a/src/test/resources/testData/formatter/largeprotofile-before.proto
+++ b/src/test/resources/testData/formatter/largeprotofile-before.proto
@@ -1,0 +1,115 @@
+// Copyright 2022-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+message Test1 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test2 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test3 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test4 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test5 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test6 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test7 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test8 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test9 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test10 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test11 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test12 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test13 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test14 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test15 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test16 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test17 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test18 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test19 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test20 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test21 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test22 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test23 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test24 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test25 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test26 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test27 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test28 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test29 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test30 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test31 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test32 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test33 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test34 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test35 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test36 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test37 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test38 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test39 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test40 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test41 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test42 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test43 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test44 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test45 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test46 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test47 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test48 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test49 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test50 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test51 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test52 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test53 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test54 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test55 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test56 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test57 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test58 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test59 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test60 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test61 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test62 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test63 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test64 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test65 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test66 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test67 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test68 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test69 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test70 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test71 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test72 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test73 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test74 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test75 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test76 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test77 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test78 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test79 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test80 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test81 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test82 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test83 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test84 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test85 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test86 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test87 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test88 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test89 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test90 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test91 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test92 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test93 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test94 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test95 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test96 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test97 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test98 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test99 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }
+message Test100 { string s = 1; int64 i64 = 2; bytes b = 3; repeated string rs = 4; }


### PR DESCRIPTION
The previous implementation of formatting would take each chunk of stdout (up to 8192 chars), trim any trailing newlines, and then join the chunks together with a newline at the end. This causes short inputs to be missing a trailing newline at EOF and also in some cases caused newlines to be inserted in the middle of chunks of a protobuf file causing syntax errors.

Update the plugin to stop trimming the end of stdout chunks and join without newlines, preserving output exactly as-is from buf format. Update the tests to add a new larger file and fix the expected result of the first test to add the trailing newline at EOF. Now both inputs match the output of 'buf format' exactly.

Fixes #180.