### PR TITLE
Use buf CLI from Maven Central

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,12 +57,6 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
 
-      # Setup Go (including module cache) for license-header
-      - uses: actions/setup-go@v5
-        with:
-          go-version: 'stable'
-          check-latest: true
-
       # Set environment variables
       - name: Export Properties
         id: properties
@@ -126,6 +120,22 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           gradle-home-cache-cleanup: true
+
+      # Setup Go (including module cache) for license-header
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          check-latest: true
+
+      - name: Cache Go Modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: "${{ runner.os }}-gomod-build-${{ hashFiles('gradle.properties', 'gradle/libs.versions.toml') }}"
+          restore-keys:
+            "${{ runner.os }}-gomod-build-"
 
       # Run tests
       - name: Run Tests

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ buf = "1.28.1"
 junit = "5.10.2"
 
 # plugins
-dokka = "1.9.20"
 kotlin = "1.9.23"
 changelog = "2.2.0"
 gradleIntelliJPlugin = "1.17.3"
@@ -15,6 +14,7 @@ osdetector = "1.7.3"
 
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }
+buf = { module = "build.buf:buf", version.ref = "buf" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
@@ -22,7 +22,6 @@ junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 gradleIntelliJPlugin = { id = "org.jetbrains.intellij", version.ref = "gradleIntelliJPlugin" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }


### PR DESCRIPTION
Instead of needing to go install the Buf CLI with each build, we should pull the dependency from Maven Central (which also has the benefit of caching it).

This also will ensure that dependabot will keep it updated.