### PR TITLE
Reduce scope to only search project files

### DIFF
--- a/src/main/kotlin/build/buf/intellij/annotator/BufAnalyzeUtils.kt
+++ b/src/main/kotlin/build/buf/intellij/annotator/BufAnalyzeUtils.kt
@@ -132,7 +132,7 @@ object BufAnalyzeUtils {
             val lintIssues =
                 if (project.bufSettings.state.backgroundLintingEnabled) {
                     runBufCommand(project, owner, workingDirectory, listOf("lint", "--error-format=json"))
-                        .mapNotNull { BufIssue.fromJSON(it) }
+                        .mapNotNull { BufIssue.fromJSON(it).getOrNull() }
                 } else {
                     emptyList()
                 }
@@ -153,7 +153,7 @@ object BufAnalyzeUtils {
                         owner,
                         workingDirectory,
                         listOf("breaking", "--error-format=json") + breakingArguments,
-                    ).mapNotNull { BufIssue.fromJSON(it) }
+                    ).mapNotNull { BufIssue.fromJSON(it).getOrNull() }
                 } else {
                     emptyList()
                 }

--- a/src/main/kotlin/build/buf/intellij/index/BufIndexes.kt
+++ b/src/main/kotlin/build/buf/intellij/index/BufIndexes.kt
@@ -38,7 +38,7 @@ object BufIndexes {
     fun getProjectModuleKeys(project: Project): Collection<ModuleKey> = getProjectIndexKeys(MODULE_KEY_INDEX_ID, project)
 
     private fun <K : Any> getProjectIndexKeys(indexId: ID<K, Void>, project: Project): Collection<K> {
-        val scope = GlobalSearchScope.allScope(project)
+        val scope = GlobalSearchScope.projectScope(project)
         return FileBasedIndex.getInstance().getAllKeys(indexId, project).filter {
             // NOTE: getAllKeys(..., project) isn't actually filtering out keys that only exist in the project.
             // Filter the results to ensure that we only return keys that were indexed from the project's files.

--- a/src/main/kotlin/build/buf/intellij/model/BufIssue.kt
+++ b/src/main/kotlin/build/buf/intellij/model/BufIssue.kt
@@ -30,10 +30,8 @@ data class BufIssue(
         get() = type == "COMPILE"
 
     companion object {
-        fun fromJSON(text: String): BufIssue? = try {
+        fun fromJSON(text: String): Result<BufIssue> = runCatching {
             Gson().fromJson(text, BufIssue::class.java)
-        } catch (th: Throwable) {
-            null
         }
     }
 }

--- a/src/test/kotlin/build/buf/intellij/model/BufIssueTest.kt
+++ b/src/test/kotlin/build/buf/intellij/model/BufIssueTest.kt
@@ -32,7 +32,7 @@ class BufIssueTest {
                 "message": "some message"
             }
             """.trimIndent(),
-        )
+        ).getOrNull()
         assertNotNull(issue!!, "failed to deserialize issue from JSON")
         assertEquals(1, issue.startLine)
         assertEquals(2, issue.endLine)


### PR DESCRIPTION
In BufIndexes, we don't need to search libraries and only need to search across project files to filter the returned buf.yaml/buf.lock index entries. Update BufIssue to use Result class to mirror other classes.