### PR TITLE
Implement support for refreshing proto roots

### DIFF
--- a/src/main/kotlin/build/buf/intellij/BufLockFileTypeOverrider.kt
+++ b/src/main/kotlin/build/buf/intellij/BufLockFileTypeOverrider.kt
@@ -21,7 +21,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import org.jetbrains.yaml.YAMLFileType
 
 /**
- * Make sure `buf.lock` files are treated as YAML files, so they are parsed to PSI for BufModuleIndex to consume.
+ * Make sure `buf.lock` files are treated as YAML files, so they are parsed to PSI for ModuleKeyIndex to consume.
  *
  * See [build.buf.intellij.index.ModuleKeyIndex].
  */

--- a/src/main/kotlin/build/buf/intellij/index/BufIndexes.kt
+++ b/src/main/kotlin/build/buf/intellij/index/BufIndexes.kt
@@ -24,8 +24,8 @@ import com.intellij.util.indexing.ID
  * Contains utility methods to retrieve data from `buf.yaml` and `buf.lock` indexes.
  */
 object BufIndexes {
-    internal val BUF_MODULE_CONFIG_INDEX_ID = ID.create<BufModuleConfig, Void>("BufModuleConfigIndex")
-    internal val MODULE_KEY_INDEX_ID = ID.create<ModuleKey, Void>("BufModuleKeyIndex")
+    val BUF_MODULE_CONFIG_INDEX_ID = ID.create<BufModuleConfig, Void>("BufModuleConfigIndex")
+    val MODULE_KEY_INDEX_ID = ID.create<ModuleKey, Void>("BufModuleKeyIndex")
 
     /**
      * Returns all [BufModuleConfig] instances parsed from `buf.yaml` files in the [Project].

--- a/src/main/kotlin/build/buf/intellij/resolve/BufModuleKeysUserData.kt
+++ b/src/main/kotlin/build/buf/intellij/resolve/BufModuleKeysUserData.kt
@@ -1,0 +1,25 @@
+// Copyright 2022-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buf.intellij.resolve
+
+import build.buf.intellij.module.ModuleKey
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.UserDataHolderBase
+
+data class BufModuleKeysUserData(val moduleKeys: Set<ModuleKey>) : UserDataHolderBase() {
+    companion object {
+        val KEY = Key.create<BufModuleKeysUserData>("BUF_ADDITIONAL_ROOTS")
+    }
+}

--- a/src/main/kotlin/build/buf/intellij/resolve/RefreshAdditionalBufRoots.kt
+++ b/src/main/kotlin/build/buf/intellij/resolve/RefreshAdditionalBufRoots.kt
@@ -1,0 +1,75 @@
+// Copyright 2022-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buf.intellij.resolve
+
+import build.buf.intellij.config.BufConfig
+import build.buf.intellij.index.BufIndexes
+import build.buf.intellij.module.ModuleKey
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.RootsChangeRescanningInfo
+import com.intellij.openapi.roots.ex.ProjectRootManagerEx
+import com.intellij.openapi.startup.StartupActivity
+import com.intellij.openapi.util.EmptyRunnable
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+
+class RefreshAdditionalBufRoots : StartupActivity {
+
+    override fun runActivity(project: Project) {
+        project.messageBus.connect().subscribe(
+            VirtualFileManager.VFS_CHANGES,
+            object : BulkFileListener {
+                override fun after(events: MutableList<out VFileEvent>) {
+                    var bufLockChanged = false
+                    for (event in events) {
+                        if (event.file?.name == BufConfig.BUF_LOCK) {
+                            bufLockChanged = true
+                            break
+                        }
+                    }
+                    if (bufLockChanged) {
+                        updateUserRoots(project)
+                    }
+                }
+            },
+        )
+        updateUserRoots(project)
+    }
+
+    private fun updateUserRoots(project: Project) {
+        DumbService.getInstance(project).runWhenSmart {
+            val existingModuleKeys = project.getUserData(BufModuleKeysUserData.KEY)?.moduleKeys ?: emptySet()
+            val newModuleKeys = hashSetOf<ModuleKey>()
+            // TODO: This still can return stale data after VFS changes.
+            // Unclear how to ensure we run this after indexing has completed.
+            // There don't appear to be any message bus changes that fire when indexing completes.
+            for (moduleKey in BufIndexes.getProjectModuleKeys(project)) {
+                newModuleKeys.add(moduleKey)
+            }
+            if (existingModuleKeys != newModuleKeys) {
+                project.putUserData(BufModuleKeysUserData.KEY, BufModuleKeysUserData(newModuleKeys))
+                ApplicationManager.getApplication().runWriteAction {
+                    ProjectRootManagerEx.getInstanceEx(project).makeRootsChange(
+                        EmptyRunnable.getInstance(),
+                        RootsChangeRescanningInfo.RESCAN_DEPENDENCIES_IF_NEEDED,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,7 @@
     <depends optional="true" config-file="kanro-protobuf-plugin-support.xml">io.kanro.idea.plugin.protobuf</depends>
 
     <extensions defaultExtensionNs="com.intellij">
+        <postStartupActivity implementation="build.buf.intellij.resolve.RefreshAdditionalBufRoots"/>
         <fileTypeOverrider implementation="build.buf.intellij.BufLockFileTypeOverrider"/>
         <fileBasedIndex implementation="build.buf.intellij.index.BufModuleConfigIndex"/>
         <fileBasedIndex implementation="build.buf.intellij.index.ModuleKeyIndex"/>


### PR DESCRIPTION
When changes are made to buf.lock files, we should attempt to refresh the additional library roots. Additionally, remove access to the index in the BufRootsProvider to avoid infinite recursion and simplify code.