### PR TITLE
Fix logging of expected exit codes

### DIFF
--- a/src/main/kotlin/build/buf/intellij/annotator/BufAnalyzePass.kt
+++ b/src/main/kotlin/build/buf/intellij/annotator/BufAnalyzePass.kt
@@ -274,6 +274,7 @@ fun AnnotationHolder.createAnnotationsForFile(
     for (issue in filteredIssues) {
         val severity = if (issue.isCompileError) HighlightSeverity.ERROR else HighlightSeverity.WARNING
         val annotationBuilder = newAnnotation(severity, issue.message)
+            // TODO: Should handle file-level lint warnings here: https://github.com/bufbuild/intellij-buf/issues/215
             .range(issue.toTextRange(doc) ?: continue)
             .problemGroup { issue.type }
             .needsUpdateOnTyping(true)


### PR DESCRIPTION
Both the lint and breaking change command are expected to return exit code 100 when issues are found. Update the logging to omit logging these cases so we only log warnings if a real failure occurs trying to run the Buf CLI.

Additionally, add a comment regarding file-level lint warnings (which are currently unsupported).