### PR TITLE
Run buf build on startup to prime cache

### DIFF
--- a/src/main/kotlin/build/buf/intellij/resolve/RefreshAdditionalBufRoots.kt
+++ b/src/main/kotlin/build/buf/intellij/resolve/RefreshAdditionalBufRoots.kt
@@ -109,11 +109,11 @@ class RefreshAdditionalBufRoots : StartupActivity {
                         disposable,
                         bufYaml.parent.toNioPath(),
                         listOf("build"),
-//                        expectedExitCodes = setOf(0, 1),
+                        expectedExitCodes = setOf(0, 1),
                     )
                 } finally {
                     val elapsed = System.nanoTime() - start
-                    LOG.warn("built ${bufYaml.path} in ${TimeUnit.NANOSECONDS.toMillis(elapsed)}ms")
+                    LOG.debug("built ${bufYaml.path} in ${TimeUnit.NANOSECONDS.toMillis(elapsed)}ms")
                     disposable.dispose()
                 }
             }

--- a/src/main/kotlin/build/buf/intellij/resolve/RefreshAdditionalBufRoots.kt
+++ b/src/main/kotlin/build/buf/intellij/resolve/RefreshAdditionalBufRoots.kt
@@ -85,10 +85,12 @@ class RefreshAdditionalBufRoots : StartupActivity {
                 project.putUserData(BufModuleKeysUserData.KEY, BufModuleKeysUserData(newModuleKeys))
                 ApplicationManager.getApplication().invokeLater {
                     ApplicationManager.getApplication().runWriteAction {
-                        ProjectRootManagerEx.getInstanceEx(project).makeRootsChange(
-                            EmptyRunnable.getInstance(),
-                            RootsChangeRescanningInfo.RESCAN_DEPENDENCIES_IF_NEEDED,
-                        )
+                        if (!project.isDisposed) {
+                            ProjectRootManagerEx.getInstanceEx(project).makeRootsChange(
+                                EmptyRunnable.getInstance(),
+                                RootsChangeRescanningInfo.RESCAN_DEPENDENCIES_IF_NEEDED,
+                            )
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/build/buf/intellij/resolve/RefreshAdditionalBufRoots.kt
+++ b/src/main/kotlin/build/buf/intellij/resolve/RefreshAdditionalBufRoots.kt
@@ -97,7 +97,7 @@ class RefreshAdditionalBufRoots : StartupActivity {
             val bufLock = bufDir.findFileByRelativePath(BufConfig.BUF_LOCK) ?: continue
             val bufLockYamlFile = PsiManager.getInstance(project).findFile(bufLock) as? YAMLFile ?: continue
             val bufLockDeps = YAMLUtil.getQualifiedKeyInFile(bufLockYamlFile, "deps")?.value as? YAMLSequence ?: continue
-            if (bufLockDeps.items.isNotEmpty()) {
+            if (bufLockDeps.items.isEmpty()) {
                 continue
             }
             runBlocking {
@@ -109,11 +109,11 @@ class RefreshAdditionalBufRoots : StartupActivity {
                         disposable,
                         bufYaml.parent.toNioPath(),
                         listOf("build"),
-                        expectedExitCodes = setOf(0, 1),
+//                        expectedExitCodes = setOf(0, 1),
                     )
                 } finally {
                     val elapsed = System.nanoTime() - start
-                    LOG.debug("built ${bufYaml.path} in ${TimeUnit.NANOSECONDS.toMillis(elapsed)}ms")
+                    LOG.warn("built ${bufYaml.path} in ${TimeUnit.NANOSECONDS.toMillis(elapsed)}ms")
                     disposable.dispose()
                 }
             }


### PR DESCRIPTION
In order to correctly resolve dependencies and add source roots on startup, we should trigger a 'buf build' on a separate thread during startup to populate the cache with any dependencies.