### PR TITLE
Filter out files in excluded directories

### DIFF
--- a/src/main/kotlin/build/buf/intellij/index/BufIndexes.kt
+++ b/src/main/kotlin/build/buf/intellij/index/BufIndexes.kt
@@ -41,12 +41,13 @@ object BufIndexes {
     private fun <K : Any> getProjectIndexKeys(indexId: ID<K, Void>, project: Project): Collection<K> {
         val scope = GlobalSearchScope.projectScope(project)
         val fileBasedIndex = FileBasedIndex.getInstance()
+        val projectFileIndex = ProjectRootManager.getInstance(project).fileIndex
         return fileBasedIndex.getAllKeys(indexId, project).filter {
             // NOTE: getAllKeys(..., project) isn't actually filtering out keys that only exist in the project.
             // Filter the results to ensure that we only return keys that were indexed from the project's files.
             // Exclude any files found in directories which are marked as excluded.
             fileBasedIndex.getContainingFiles(indexId, it, scope)
-                .any { file -> !ProjectRootManager.getInstance(project).fileIndex.isExcluded(file) }
+                .any { file -> !projectFileIndex.isExcluded(file) }
         }
     }
 }


### PR DESCRIPTION
Don't return buf.yaml/buf.lock index contents for files which are found in excluded directories.