### PR TITLE
Fix compatilbility issue with latest EAP

### DIFF
--- a/src/main/kotlin/build/buf/intellij/configurable/BufConfigurable.kt
+++ b/src/main/kotlin/build/buf/intellij/configurable/BufConfigurable.kt
@@ -14,7 +14,6 @@
 
 package build.buf.intellij.configurable
 
-import ai.grazie.nlp.utils.tokenizeByWhitespace
 import build.buf.intellij.BufBundle
 import build.buf.intellij.settings.BufProjectSettingsService
 import build.buf.intellij.settings.bufSettings
@@ -73,7 +72,7 @@ class BufConfigurable(
             row("buf breaking") {
                 textField().bindText(
                     { state.breakingArgumentsOverride.joinToString(separator = " ") },
-                    { text -> state.breakingArgumentsOverride = text.tokenizeByWhitespace() },
+                    { text -> state.breakingArgumentsOverride = text.split("\\s+".toRegex()).filter { it.isNotBlank() } },
                 ).columns(COLUMNS_LARGE)
                     .align(Align.FILL)
                     .comment("For example, --against .git#tag=v1.0.0. By default, breaking changes will be verified against uncommitted changes.")


### PR DESCRIPTION
Update the plugin to stop calling tokenizeByWhitespace (this method is not available in 2024.2 EAP).