### PR TITLE
Avoid changing file contents if format failed

### DIFF
--- a/src/test/kotlin/build/buf/intellij/formatter/BufFormatterTest.kt
+++ b/src/test/kotlin/build/buf/intellij/formatter/BufFormatterTest.kt
@@ -72,4 +72,22 @@ class BufFormatterTest : BufTestBase() {
         val expected = findTestDataFolder().resolve("formatter/largeprotofile-after.proto").readText()
         myFixture.checkResult(expected)
     }
+
+    fun testSyntaxError() {
+        val file = myFixture.configureByText(
+            "user.proto",
+            """
+            syntax = "proto3";
+            package users.v1;
+            
+            message User {
+                string a =
+            }
+            """.trimIndent(),
+        )
+        WriteCommandAction.runWriteCommandAction(project, ReformatCodeProcessor.getCommandName(), null, {
+            CodeStyleManager.getInstance(project).reformat(file)
+        })
+        myFixture.checkResult(file.text)
+    }
 }


### PR DESCRIPTION
Update formatter to check the exit code of the command, and only reformat the file if it exits with a 0 exit code. If `buf format` returns an error, show up to 10 lines of stderr to help diagnose any issues.

Fixes #273.