### PR TITLE
Fix plugin verification

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -257,5 +257,6 @@ tasks {
 
     runPluginVerifier {
         ideVersions.set(testIntellij.versions.versionList.get().split(',').map(String::trim).filter(String::isNotEmpty))
+        freeArgs = listOf("-mute", "TemplateWordInPluginId")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion=0.4.2
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=223
-pluginUntilBuild=999.*
+pluginUntilBuild=243.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IU
 platformVersion=2022.3

--- a/gradle/test-intellij.versions.toml
+++ b/gradle/test-intellij.versions.toml
@@ -1,2 +1,3 @@
 [versions]
-versionList = "IIC-241.15989.150,IIC-223.8836.41"
+# https://jb.gg/intellij-platform-builds-list
+versionList = "IIC-243.21565.193,IIC-223.8836.41"


### PR DESCRIPTION
Mute the TemplateWordInPluginId (we've previously published the plugin) and set a valid pluginUntilBuild setting (this will mean we'll have to periodically re-test and re-publish for new IDE versions).

Bump the plugin verification versions to test with the latest released IIC version.