### PR TITLE
Update to larger runners for build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
   # Prepare environment and build the plugin
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     outputs:
       version: ${{ steps.properties.outputs.version }}
       changelog: ${{ steps.properties.outputs.changelog }}
@@ -97,7 +97,7 @@ jobs:
   test:
     name: Test
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     steps:
 
       # Check out the current repository
@@ -153,7 +153,7 @@ jobs:
   inspectCode:
     name: Inspect code
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     permissions:
       contents: write
       checks: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.gradle/
 /.idea/
+/.intellijPlatform/
 /.qodana/
 /build/


### PR DESCRIPTION
CI builds are regularly running out of space. Bump to larger runners to attempt to fix.