### PR TITLE
Migrate to junit 4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,11 +40,8 @@ repositories {
 dependencies {
     buf("build.buf:buf:${libs.versions.buf.get()}:${osdetector.classifier}@exe")
 
-    testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.junit.jupiter)
-    testRuntimeOnly(libs.junit.jupiter.engine)
-    testRuntimeOnly(libs.junit.vintage.engine)
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(libs.assertj)
+    testImplementation(libs.junit)
 
     // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
     intellijPlatform {
@@ -60,7 +57,6 @@ dependencies {
         pluginVerifier()
         zipSigner()
         testFramework(TestFrameworkType.Platform)
-        testFramework(TestFrameworkType.JUnit5)
     }
 }
 
@@ -237,7 +233,6 @@ tasks {
         environment("BUF_CACHE_DIR", File(project.projectDir.path + "/src/test/resources/testData/cache").absolutePath)
         systemProperty("NO_FS_ROOTS_ACCESS_CHECK", "true") // weird issue on linux
         systemProperty("BUF_CLI", buf.asPath)
-        useJUnitPlatform()
     }
 
     wrapper {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,9 @@
 [versions]
 # libraries
 annotations = "26.0.1"
+assertj = "3.27.1"
 buf = "1.48.0"
-junit = "5.11.4"
+junit = "4.13.2"
 
 # plugins
 kotlin = "1.9.25"
@@ -15,11 +16,9 @@ spotless = "6.25.0"
 
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }
+assertj = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 buf = { module = "build.buf:buf", version.ref = "buf" }
-junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
-junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
-junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
+junit = { module = "junit:junit", version.ref = "junit" }
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }

--- a/src/test/kotlin/build/buf/intellij/base/BufTestBase.kt
+++ b/src/test/kotlin/build/buf/intellij/base/BufTestBase.kt
@@ -18,7 +18,7 @@ import build.buf.intellij.settings.bufSettings
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.testFramework.builders.ModuleFixtureBuilder
 import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase
-import org.junit.jupiter.api.Assertions
+import org.assertj.core.api.Assertions
 import java.io.File
 import java.nio.file.Path
 
@@ -53,7 +53,7 @@ abstract class BufTestBase : CodeInsightFixtureTestCase<ModuleFixtureBuilder<*>>
     protected fun findTestDataFolder(): Path {
         val result = Path.of(ClassLoader.getSystemResource("testData").toURI())
             .resolve(basePath)
-        Assertions.assertNotNull(result)
+        Assertions.assertThat(result).isNotNull()
         return result
     }
 

--- a/src/test/kotlin/build/buf/intellij/cas/CASDigestTest.kt
+++ b/src/test/kotlin/build/buf/intellij/cas/CASDigestTest.kt
@@ -15,10 +15,8 @@
 package build.buf.intellij.cas
 
 import org.apache.commons.codec.binary.Hex
-import org.junit.jupiter.api.Assertions.assertArrayEquals
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.assertj.core.api.Assertions
+import org.junit.Test
 import java.io.StringReader
 import java.util.concurrent.ThreadLocalRandom
 
@@ -30,13 +28,13 @@ class CASDigestTest {
         val hex = Hex.encodeHexString(randomDigestBytes)
         val digestStr = "shake256:$hex"
         val digest = CASDigest.parse(digestStr).getOrThrow()
-        assertEquals(digestStr, digest.toString())
-        assertEquals(CASDigestType.SHAKE256, digest.digestType)
-        assertEquals(hex, digest.hex)
-        assertArrayEquals(randomDigestBytes, digest.value())
+        Assertions.assertThat(digest.toString()).isEqualTo(digestStr)
+        Assertions.assertThat(digest.digestType).isEqualTo(CASDigestType.SHAKE256)
+        Assertions.assertThat(digest.hex).isEqualTo(hex)
+        Assertions.assertThat(digest.value()).isEqualTo(randomDigestBytes)
         for (expectedFailure in listOf("othertype:$hex", "shake256:${hex.substring(0, 64)}", "$hex")) {
-            assertThrows<IllegalArgumentException> { CASDigest.parse(expectedFailure).getOrThrow() }
-            assertThrows<IllegalArgumentException> { CASDigest.parse(StringReader(expectedFailure)).getOrThrow() }
+            Assertions.assertThatThrownBy { CASDigest.parse(expectedFailure).getOrThrow() }.isInstanceOf(IllegalArgumentException::class.java)
+            Assertions.assertThatThrownBy { CASDigest.parse(StringReader(expectedFailure)).getOrThrow() }.isInstanceOf(IllegalArgumentException::class.java)
         }
     }
 }

--- a/src/test/kotlin/build/buf/intellij/cas/FileNodeTest.kt
+++ b/src/test/kotlin/build/buf/intellij/cas/FileNodeTest.kt
@@ -15,9 +15,8 @@
 package build.buf.intellij.cas
 
 import org.apache.commons.codec.binary.Hex
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.assertj.core.api.Assertions
+import org.junit.Test
 import java.util.concurrent.ThreadLocalRandom
 
 class FileNodeTest {
@@ -28,9 +27,9 @@ class FileNodeTest {
         val digestStr = "shake256:${Hex.encodeHexString(randomDigestBytes)}"
         val fileNodeStr = "$digestStr  path/to/file.proto"
         val fileNode = FileNode.parse(fileNodeStr).getOrThrow()
-        assertEquals("path/to/file.proto", fileNode.path)
-        assertEquals(digestStr, fileNode.digest.toString())
-        assertEquals(fileNodeStr, fileNode.toString())
+        Assertions.assertThat(fileNode.path).isEqualTo("path/to/file.proto")
+        Assertions.assertThat(fileNode.digest.toString()).isEqualTo(digestStr)
+        Assertions.assertThat(fileNode.toString()).isEqualTo(fileNodeStr)
         val invalidNodeStrs = listOf(
             "$digestStr  ",
             "$digestStr  /file.proto",
@@ -40,7 +39,8 @@ class FileNodeTest {
             "shake256:abc  file.proto",
         )
         for (invalid in invalidNodeStrs) {
-            assertThrows<IllegalArgumentException>("invalid node: $invalid") { FileNode.parse(invalid).getOrThrow() }
+            Assertions.assertThatThrownBy { FileNode.parse(invalid).getOrThrow() }
+                .isInstanceOf(IllegalArgumentException::class.java)
         }
     }
 }

--- a/src/test/kotlin/build/buf/intellij/cas/ManifestTest.kt
+++ b/src/test/kotlin/build/buf/intellij/cas/ManifestTest.kt
@@ -16,7 +16,7 @@ package build.buf.intellij.cas
 
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import org.junit.jupiter.api.Assertions
+import org.assertj.core.api.Assertions
 import java.nio.file.Path
 
 class ManifestTest : BasePlatformTestCase() {
@@ -25,21 +25,21 @@ class ManifestTest : BasePlatformTestCase() {
     fun testManifest() {
         val cachePath = Path.of(ClassLoader.getSystemResource("testData").toURI())
             .resolve("cachev2/v2/module/buf.build/googleapis/googleapis")
-        Assertions.assertNotNull(cachePath)
+        Assertions.assertThat(cachePath).isNotNull()
         val repoPath = LocalFileSystem.getInstance().findFileByNioFile(cachePath)
-        Assertions.assertNotNull(repoPath)
+        Assertions.assertThat(repoPath).isNotNull()
         val commitPath = cachePath.resolve("commits/cc916c31859748a68fd229a3c8d7a2e8")
         val manifestDigest = CASDigest.parse(commitPath.toFile().readText().trim()).getOrThrow()
         val manifestPath = cachePath.resolve("blobs/${manifestDigest.hex.substring(0, 2)}/${manifestDigest.hex.substring(2)}")
         val manifest = Manifest.parse(manifestPath.toFile().readText()).getOrThrow()
-        Assertions.assertFalse(manifest.getFileNodes().isEmpty())
+        Assertions.assertThat(manifest.getFileNodes()).isNotEmpty()
         // Verify round tripping.
-        Assertions.assertEquals(manifest, Manifest.parse(manifest.toString()).getOrThrow())
+        Assertions.assertThat(Manifest.parse(manifest.toString()).getOrThrow()).isEqualTo(manifest)
         val moneyFileNode = manifest.getFileNode("google/type/money.proto")!!
-        Assertions.assertNotNull(moneyFileNode.digest)
-        Assertions.assertNotNull(moneyFileNode.path)
-        Assertions.assertEquals(moneyFileNode.digest, manifest.getDigest(moneyFileNode.path))
-        Assertions.assertNull(manifest.getFileNode("non/existing/file.proto"))
-        Assertions.assertNull(manifest.getDigest("non/existing/file.proto"))
+        Assertions.assertThat(moneyFileNode.digest).isNotNull()
+        Assertions.assertThat(moneyFileNode.path).isNotNull()
+        Assertions.assertThat(manifest.getDigest(moneyFileNode.path)).isEqualTo(moneyFileNode.digest)
+        Assertions.assertThat(manifest.getFileNode("non/existing/file.proto")).isNull()
+        Assertions.assertThat(manifest.getDigest("non/existing/file.proto")).isNull()
     }
 }

--- a/src/test/kotlin/build/buf/intellij/completion/BufCompletionTest.kt
+++ b/src/test/kotlin/build/buf/intellij/completion/BufCompletionTest.kt
@@ -15,7 +15,7 @@
 package build.buf.intellij.completion
 
 import build.buf.intellij.base.BufTestBase
-import org.junit.jupiter.api.Assertions
+import org.assertj.core.api.Assertions
 
 class BufCompletionTest : BufTestBase() {
     override fun getBasePath(): String = "completion"
@@ -23,7 +23,7 @@ class BufCompletionTest : BufTestBase() {
     fun testExternalBufModule() {
         configureByFolder("external", "order.proto")
         val suggestions = myFixture.completeBasic()?.map { it.lookupString }
-        Assertions.assertNotNull(suggestions)
+        Assertions.assertThat(suggestions).isNotNull()
         assertTrue(suggestions?.contains("google/type/money.proto") ?: false)
     }
 }

--- a/src/test/kotlin/build/buf/intellij/model/BufIssueTest.kt
+++ b/src/test/kotlin/build/buf/intellij/model/BufIssueTest.kt
@@ -14,9 +14,8 @@
 
 package build.buf.intellij.model
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Test
+import org.assertj.core.api.Assertions
+import org.junit.Test
 
 class BufIssueTest {
     @Test
@@ -33,12 +32,12 @@ class BufIssueTest {
             }
             """.trimIndent(),
         ).getOrNull()
-        assertNotNull(issue!!, "failed to deserialize issue from JSON")
-        assertEquals(1, issue.startLine)
-        assertEquals(2, issue.endLine)
-        assertEquals(3, issue.startColumn)
-        assertEquals(4, issue.endColumn)
-        assertEquals("some type", issue.type)
-        assertEquals("some message", issue.message)
+        Assertions.assertThat(issue!!).isNotNull()
+        Assertions.assertThat(issue.startLine).isEqualTo(1)
+        Assertions.assertThat(issue.endLine).isEqualTo(2)
+        Assertions.assertThat(issue.startColumn).isEqualTo(3)
+        Assertions.assertThat(issue.endColumn).isEqualTo(4)
+        Assertions.assertThat(issue.type).isEqualTo("some type")
+        Assertions.assertThat(issue.message).isEqualTo("some message")
     }
 }

--- a/src/test/kotlin/build/buf/intellij/module/ModuleDigestTest.kt
+++ b/src/test/kotlin/build/buf/intellij/module/ModuleDigestTest.kt
@@ -16,9 +16,8 @@ package build.buf.intellij.module
 
 import build.buf.intellij.cas.CASDigestType
 import org.apache.commons.codec.binary.Hex
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.assertj.core.api.Assertions
+import org.junit.Test
 import java.util.concurrent.ThreadLocalRandom
 
 class ModuleDigestTest {
@@ -29,12 +28,13 @@ class ModuleDigestTest {
         val hex = Hex.encodeHexString(randomDigestBytes)
         val digestStr = "b5:$hex"
         val digest = ModuleDigest.parse(digestStr).getOrThrow()
-        Assertions.assertEquals(digestStr, digest.toString())
-        Assertions.assertEquals(ModuleDigestType.B5, digest.digestType)
-        Assertions.assertEquals(hex, digest.hex)
-        Assertions.assertArrayEquals(randomDigestBytes, digest.value())
+        Assertions.assertThat(digest.toString()).isEqualTo(digestStr)
+        Assertions.assertThat(digest.digestType).isEqualTo(ModuleDigestType.B5)
+        Assertions.assertThat(digest.hex).isEqualTo(hex)
+        Assertions.assertThat(digest.value()).isEqualTo(randomDigestBytes)
         for (expectedFailure in listOf("b4:$hex", hex)) {
-            assertThrows<IllegalArgumentException> { ModuleDigest.parse(expectedFailure).getOrThrow() }
+            Assertions.assertThatThrownBy { ModuleDigest.parse(expectedFailure).getOrThrow() }
+                .isInstanceOf(IllegalArgumentException::class.java)
         }
     }
 }

--- a/src/test/kotlin/build/buf/intellij/module/ModuleFullNameTest.kt
+++ b/src/test/kotlin/build/buf/intellij/module/ModuleFullNameTest.kt
@@ -14,18 +14,17 @@
 
 package build.buf.intellij.module
 
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.assertj.core.api.Assertions
+import org.junit.Test
 
 class ModuleFullNameTest {
     @Test
     fun testModuleFullName() {
         val fullName = ModuleFullName.parse("buf.build/bufbuild/buf").getOrThrow()
-        Assertions.assertEquals("buf.build", fullName.registry)
-        Assertions.assertEquals("bufbuild", fullName.owner)
-        Assertions.assertEquals("buf", fullName.name)
-        Assertions.assertEquals(fullName, ModuleFullName.parse(fullName.toString()).getOrThrow())
+        Assertions.assertThat(fullName.registry).isEqualTo("buf.build")
+        Assertions.assertThat(fullName.owner).isEqualTo("bufbuild")
+        Assertions.assertThat(fullName.name).isEqualTo("buf")
+        Assertions.assertThat(ModuleFullName.parse(fullName.toString()).getOrThrow()).isEqualTo(fullName)
 
         val invalidFullNames = listOf(
             "https://buf.build/bufbuild/buf",
@@ -36,7 +35,8 @@ class ModuleFullNameTest {
             "buf.build/ / ",
         )
         for (invalidFullName in invalidFullNames) {
-            assertThrows<IllegalArgumentException> { ModuleFullName.parse(invalidFullName).getOrThrow() }
+            Assertions.assertThatThrownBy { ModuleFullName.parse(invalidFullName).getOrThrow() }
+                .isInstanceOf(IllegalArgumentException::class.java)
         }
     }
 }

--- a/src/test/kotlin/build/buf/intellij/module/UUIDUtilsTest.kt
+++ b/src/test/kotlin/build/buf/intellij/module/UUIDUtilsTest.kt
@@ -14,8 +14,8 @@
 
 package build.buf.intellij.module
 
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
+import org.assertj.core.api.Assertions
+import org.junit.Test
 import java.util.UUID
 
 class UUIDUtilsTest {
@@ -23,8 +23,8 @@ class UUIDUtilsTest {
     fun testDashless() {
         val uuid = UUID.randomUUID()
         val dashless = uuid.toDashless()
-        Assertions.assertFalse(dashless.contains('-'))
-        Assertions.assertEquals(32, dashless.length)
-        Assertions.assertEquals(uuid, UUIDUtils.fromDashless(dashless).getOrThrow())
+        Assertions.assertThat(dashless).doesNotContain("-")
+            .hasSize(32)
+        Assertions.assertThat(UUIDUtils.fromDashless(dashless).getOrThrow()).isEqualTo(uuid)
     }
 }


### PR DESCRIPTION
Upgrading to the latest IntelliJ platform plugin is failing with issues related to JUnit 5 in https://github.com/bufbuild/intellij-buf/pull/283. We don't require use of JUnit 5 so migrate to JUnit 4 to make it easier to adopt newer platform plugins.