### PR TITLE
Fix CI plugin verification tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,7 +117,11 @@ intellijPlatform {
 
     pluginVerification {
         ides {
-            recommended()
+            select {
+                // Temporary workaround for https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1882
+                // The Kanro optional dependency is causing failures to resolve required plugins in EAP 2025 tests.
+                untilBuild = providers.gradleProperty("pluginUntilVerifyBuild")
+            }
         }
         freeArgs = listOf(
             "-mute",

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@ pluginVersion = 0.5.0
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 242
 pluginUntilBuild = 253.*
+pluginUntilVerifyBuild = 243.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU


### PR DESCRIPTION
The plugin verification tests are failing in EAP 2025 builds since the Kanro plugin doesn't exist in the marketplace with a supported version. Update the tests to temporarily test up to 2024.3.* builds in the meantime.