### PR TITLE
Use EnvironmentUtil helpers for module cache

### DIFF
--- a/src/main/kotlin/build/buf/intellij/module/cache/BaseModuleCache.kt
+++ b/src/main/kotlin/build/buf/intellij/module/cache/BaseModuleCache.kt
@@ -15,9 +15,10 @@
 package build.buf.intellij.module.cache
 
 import com.intellij.openapi.util.SystemInfoRt
+import com.intellij.util.EnvironmentUtil
 import com.intellij.util.SystemProperties
 
-internal abstract class BaseModuleCache(env: Map<String, String> = System.getenv()) : ModuleCache {
+internal abstract class BaseModuleCache(env: Map<String, String> = EnvironmentUtil.getEnvironmentMap()) : ModuleCache {
 
     protected val bufCacheDir by lazy { getBufCacheDir(env) }
 

--- a/src/main/kotlin/build/buf/intellij/module/cache/ModuleCacheV1.kt
+++ b/src/main/kotlin/build/buf/intellij/module/cache/ModuleCacheV1.kt
@@ -16,6 +16,7 @@ package build.buf.intellij.module.cache
 
 import build.buf.intellij.module.ModuleKey
 import build.buf.intellij.module.toDashless
+import com.intellij.util.EnvironmentUtil
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -23,7 +24,7 @@ import java.nio.file.Paths
  * Cache implementation for the v1 Buf CLI cache layout.
  * Modules are cached to `${BUF_CACHE_DIR}/v1/module/data/${registry}/${owner}/${name}/${commit}`.
  */
-internal class ModuleCacheV1(env: Map<String, String> = System.getenv()) : BaseModuleCache(env) {
+internal class ModuleCacheV1(env: Map<String, String> = EnvironmentUtil.getEnvironmentMap()) : BaseModuleCache(env) {
     override fun moduleDataRoot(): Path = Paths.get("$bufCacheDir/v1/module/data")
 
     override fun moduleDataPathForModuleKey(key: ModuleKey): Path = moduleDataRoot().resolve("${key.moduleFullName}/${key.commitID.toDashless()}")

--- a/src/main/kotlin/build/buf/intellij/module/cache/ModuleCacheV2.kt
+++ b/src/main/kotlin/build/buf/intellij/module/cache/ModuleCacheV2.kt
@@ -23,6 +23,7 @@ import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.util.EnvironmentUtil
 import com.intellij.util.io.delete
 import java.io.IOException
 import java.nio.file.DirectoryNotEmptyException
@@ -40,7 +41,7 @@ import kotlin.io.path.isDirectory
  * This differs from v1/v3 in that the files are stored as a content-addressable storage (CAS).
  * To work with the IDE, we need to copy the files to a file layout based on the paths within a module.
  */
-internal class ModuleCacheV2(env: Map<String, String> = System.getenv()) : BaseModuleCache(env) {
+internal class ModuleCacheV2(env: Map<String, String> = EnvironmentUtil.getEnvironmentMap()) : BaseModuleCache(env) {
 
     override fun moduleDataRoot(): Path = Path.of(SYSTEM_BUF_MOD_CACHE)
 

--- a/src/main/kotlin/build/buf/intellij/module/cache/ModuleCacheV3.kt
+++ b/src/main/kotlin/build/buf/intellij/module/cache/ModuleCacheV3.kt
@@ -17,13 +17,14 @@ package build.buf.intellij.module.cache
 import build.buf.intellij.module.ModuleDigestType
 import build.buf.intellij.module.ModuleKey
 import build.buf.intellij.module.toDashless
+import com.intellij.util.EnvironmentUtil
 import java.nio.file.Path
 
 /**
  * Cache implementation for the v3 Buf CLI cache layout.
  * Modules are cached to `${BUF_CACHE_DIR}/v3/modules/${digestType}/${registry}/${owner}/${name}/${commit}/files`.
  */
-internal class ModuleCacheV3(env: Map<String, String> = System.getenv()) : BaseModuleCache(env) {
+internal class ModuleCacheV3(env: Map<String, String> = EnvironmentUtil.getEnvironmentMap()) : BaseModuleCache(env) {
     override fun moduleDataRoot(): Path = Path.of("$bufCacheDir/v3/modules")
 
     override fun moduleDataPathForModuleKey(key: ModuleKey): Path {


### PR DESCRIPTION
On MacOS there are multiple tickets regarding plugins and tooling not being able to access the full shell environment:

* https://youtrack.jetbrains.com/issue/IDEA-347154/The-installed-plugin-doesnt-have-access-to-environment-variables
* https://youtrack.jetbrains.com/issue/IJPL-11674/On-Mac-OS-X-IDE-doesnt-pick-up-shell-environment-when-started-from-Dock-Spotlight

The lack of environment variables causes this plugin to fail to resolve modules when the buf cache is in a non-standard location.

One of the workarounds is to modify the `environment.plist` (see [stackoverflow example](https://stackoverflow.com/questions/25385934/setting-environment-variables-via-launchd-conf-no-longer-works-in-os-x-yosemite/26586170#26586170)) which is tedious for end users.

Using `EnvironmentUtil` resolves this and is adopted in multiple Jetbrains plugins. There is a good description here describing the problem and the fix:

https://github.com/JetBrains/intellij-community/blob/6469f901a10691e32a143dca5c5aebcd653c063b/platform/util/src/com/intellij/util/EnvironmentUtil.java#L70-L87

With this change, 3rd party proto libraries resolve correctly on MacOS when the buf cache is in the non-default location (i.e. in my setup this is when `XDG_CACHE_HOME` has been set).