### PR TITLE
Update IntelliJ platform plugin to latest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
@@ -118,6 +120,12 @@ intellijPlatform {
     pluginVerification {
         ides {
             recommended()
+            select {
+                types = listOf(IntelliJPlatformType.IntellijIdea)
+                channels = listOf(ProductRelease.Channel.RELEASE)
+                sinceBuild = providers.gradleProperty("pluginSinceBuild")
+                untilBuild = providers.gradleProperty("pluginUntilBuild")
+            }
         }
         freeArgs = listOf(
             "-mute",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ junit = "4.13.2"
 # plugins
 kotlin = "2.1.0"
 changelog = "2.4.0"
-intelliJPlatform = "2.7.2"
+intelliJPlatform = "2.9.0"
 qodana = "2025.2.1"
 kover = "0.9.1"
 osdetector = "1.7.3"


### PR DESCRIPTION
Update the IntelliJ platform plugin to the latest 2.9.0. Add a new set of IDE ranges to test with plugin verification (existing `recommended()` is no longer working with the latest version). This will ensure we test with the full version range we support.