### PR TITLE
Fix build verifier on 2026.* releases

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ platformPlugins = io.kanro.idea.plugin.protobuf:2.1.0
 platformBundledPlugins = idea.plugin.protoeditor, org.jetbrains.plugins.yaml, com.intellij.modules.json
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 9.3.1
+gradleVersion = 9.5.1
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/src/main/kotlin/build/buf/intellij/annotator/BufAnalyzePass.kt
+++ b/src/main/kotlin/build/buf/intellij/annotator/BufAnalyzePass.kt
@@ -30,7 +30,6 @@ import com.intellij.codeInsight.daemon.impl.HighlightInfo
 import com.intellij.codeInsight.daemon.impl.HighlightInfoProcessor
 import com.intellij.codeInsight.daemon.impl.HighlightInfoType
 import com.intellij.codeInsight.daemon.impl.UpdateHighlightersUtil
-import com.intellij.ide.plugins.PluginManagerCore.isUnitTestMode
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
@@ -139,7 +138,7 @@ class BufAnalyzePass(
             }
         }
 
-        if (isUnitTestMode) {
+        if (ApplicationManager.getApplication().isUnitTestMode) {
             update.run()
         } else {
             factory.scheduleExternalActivity(update)

--- a/src/main/kotlin/build/buf/intellij/annotator/BufAnalyzeUtils.kt
+++ b/src/main/kotlin/build/buf/intellij/annotator/BufAnalyzeUtils.kt
@@ -29,7 +29,6 @@ import com.intellij.execution.process.ProcessOutputType
 import com.intellij.execution.wsl.WSLCommandLineOptions
 import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.execution.wsl.WslDistributionManager
-import com.intellij.ide.plugins.PluginManagerCore.isUnitTestMode
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.WriteAction
@@ -77,7 +76,7 @@ object BufAnalyzeUtils {
         return externalLinterLazyResultCache.getOrPut(project, workingDirectory) {
             lazy {
                 // This code will be executed out of read action in background thread
-                if (!isUnitTestMode) check(!ApplicationManager.getApplication().isReadAccessAllowed)
+                if (!ApplicationManager.getApplication().isUnitTestMode) check(!ApplicationManager.getApplication().isReadAccessAllowed)
                 check(project, owner, workingDirectory)
             }
         }


### PR DESCRIPTION
The `PluginManagerCore.isUnitTestMode` method is now marked internal so is failing the plugin verifier step. Update to the public replacement API to fix the build.