### PR TITLE
Fix some deprecation warnings

### DIFF
--- a/src/main/kotlin/build/buf/intellij/annotator/BufAnalyzePass.kt
+++ b/src/main/kotlin/build/buf/intellij/annotator/BufAnalyzePass.kt
@@ -216,7 +216,7 @@ class BufAnalyzePassFactory(
         if (!shouldRunPass(file)) {
             return null
         }
-        FileStatusMap.getDirtyTextRange(editor, passId) ?: return null
+        FileStatusMap.getDirtyTextRange(editor.document, file, passId) ?: return null
         return BufAnalyzePass(this, file, editor.document)
     }
 

--- a/src/main/kotlin/build/buf/intellij/annotator/BufAnalyzeUtils.kt
+++ b/src/main/kotlin/build/buf/intellij/annotator/BufAnalyzeUtils.kt
@@ -22,9 +22,9 @@ import build.buf.intellij.settings.bufSettings
 import build.buf.intellij.vendor.isProtobufFile
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.OSProcessHandler
-import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.process.ProcessOutputType
 import com.intellij.execution.wsl.WSLCommandLineOptions
 import com.intellij.execution.wsl.WSLDistribution
@@ -183,7 +183,7 @@ object BufAnalyzeUtils {
         }
         try {
             handler.addProcessListener(
-                object : ProcessAdapter() {
+                object : ProcessListener {
                     override fun onTextAvailable(event: ProcessEvent, outputType: com.intellij.openapi.util.Key<*>) {
                         when (outputType) {
                             ProcessOutputType.SYSTEM -> cmd.set(event.text.trimEnd())

--- a/src/main/kotlin/build/buf/intellij/lsp/BufVersionDetector.kt
+++ b/src/main/kotlin/build/buf/intellij/lsp/BufVersionDetector.kt
@@ -17,8 +17,8 @@ package build.buf.intellij.lsp
 import build.buf.intellij.annotator.BufAnalyzeUtils
 import build.buf.intellij.settings.BufCLIUtils
 import com.intellij.execution.process.OSProcessHandler
-import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.process.ProcessOutputType
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
@@ -102,7 +102,7 @@ object BufVersionDetector {
                 BufAnalyzeUtils.createBufCommandLine(bufExecutable, listOf("--version")),
             )
 
-            handler.addProcessListener(object : ProcessAdapter() {
+            handler.addProcessListener(object : ProcessListener {
                 override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
                     if (outputType == ProcessOutputType.STDOUT) {
                         stdout.set(event.text.trim())

--- a/src/main/kotlin/build/buf/intellij/settings/impl/BufProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/build/buf/intellij/settings/impl/BufProjectSettingsServiceImpl.kt
@@ -46,7 +46,7 @@ class BufProjectSettingsServiceImpl(
         set(newState) {
             if (_state != newState) {
                 _state = newState.copy()
-                DaemonCodeAnalyzer.getInstance(project).restart()
+                DaemonCodeAnalyzer.getInstance(project).restart("Buf settings changed")
             }
         }
 


### PR DESCRIPTION
Update to use non-deprecated APIs, fixing some deprecation warnings which show up when verifying the plugin.